### PR TITLE
Working loadtest 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
 # Mozilla Kinto Load-Tester
-FROM stackbrew/debian:sid
-
-MAINTAINER Remy HUBSCHER
+FROM debian:stable
 
 RUN \
-    apt-get update; \
+    apt-get update -y; \
     apt-get install -y python3-pip python3-venv git build-essential make; \
     apt-get install -y python3-dev libssl-dev libffi-dev; \
     git clone https://github.com/mozilla-services/ailoads-kinto /home/kinto; \
     cd /home/kinto; \
+    pip3 install virtualenv; \
     make build; \
 	apt-get remove -y -qq git build-essential make python3-pip python3-virtualenv libssl-dev libffi-dev; \
     apt-get autoremove -y -qq; \
-    apt-get clean -y 
+    apt-get clean -y;
 
 WORKDIR /home/kinto
 

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,17 @@ test: build
 test-heavy: build
 	bash -c "KINTO_SERVER_URL=$(KINTO_SERVER_URL) $(BIN)/ailoads -v -d 300 -u 10"
 
-clean: refresh
+clean:
 	rm -fr venv/ __pycache__/ *.pyc
 
 docker-build:
-	docker build -t kinto/loadtest .
+	docker build -t chartjes/kinto-loadtests .
 
 docker-run: loadtest.env
-	bash -c "docker run -e KINTO_DURATION=600 -e KINTO_NB_USERS=10 -e KINTO_SERVER_URL=$(KINTO_SERVER_URL) kinto/loadtest"
+	bash -c "docker run -e KINTO_DURATION=600 -e KINTO_NB_USERS=10 -e KINTO_SERVER_URL=$(KINTO_SERVER_URL) chartjes/kinto-loadtests"
 
 configure: build
 	@bash kinto.tpl
 
 docker-export:
-	docker save "kinto/loadtest:latest" | bzip2> kinto-latest.tar.bz2
+	docker save "chartjes/kint-loadtests:latest" | bzip2> kinto-latest.tar.bz2

--- a/kinto.json
+++ b/kinto.json
@@ -12,8 +12,7 @@
           "instance_region": "us-east-1",
           "instance_type": "m3.large",
           "run_max_time": 300,
-          "container_name": "kinto/loadtest:latest",
-          "container_url": "https://kinto-ota.dev.mozaws.net/loadsv2-images/kinto-latest.tar.bz2",
+          "container_name": "chartjes/kinto-loadtests:latest",
           "environment_data": [
             "KINTO_METRICS_STATSD_SERVER=$STATSD_HOST:$STATSD_PORT",
             "KINTO_SERVER_URL=https://kinto.stage.mozaws.net:443",


### PR DESCRIPTION
Updated Dockerfile to use different base box, tweaked makefile, fixed load test plan to use the correct Docker image

r? @mozilla-services/firefox-test-engineering 
